### PR TITLE
Issue 839

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ RUN apt-get update -q --fix-missing && \
     amavisd-new \
     arj \
     binutils \
-    bsd-mailx \
     bzip2 \
     ca-certificates \
     cabextract \

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,6 @@ run:
 		-e SPOOF_PROTECTION=1 \
 		-e ENABLE_SPAMASSASSIN=1 \
 		-e REPORT_MAIL=user1@localhost.localdomain \
-		-e REPORT_INTERVAL=monthly \
 		-e SA_TAG=-5.0 \
 		-e SA_TAG2=2.0 \
 		-e SA_KILL=3.0 \

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ run:
 		-e ENABLE_MANAGESIEVE=1 \
 		--cap-add=SYS_PTRACE \
 		-e PERMIT_DOCKER=host \
-		-e DMS_DEBUG=1 \
+		-e DMS_DEBUG=0 \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 15
 	docker run -d --name mail_privacy \

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ run:
 		-e ENABLE_CLAMAV=1 \
 		-e SPOOF_PROTECTION=1 \
 		-e ENABLE_SPAMASSASSIN=1 \
+		-e REPORT_MAIL=user1@localhost.localdomain \
+		-e REPORT_INTERVAL=monthly \
 		-e SA_TAG=-5.0 \
 		-e SA_TAG2=2.0 \
 		-e SA_KILL=3.0 \
@@ -34,7 +36,7 @@ run:
 		-e ENABLE_MANAGESIEVE=1 \
 		--cap-add=SYS_PTRACE \
 		-e PERMIT_DOCKER=host \
-		-e DMS_DEBUG=0 \
+		-e DMS_DEBUG=1 \
 		-h mail.my-domain.com -t $(NAME)
 	sleep 15
 	docker run -d --name mail_privacy \

--- a/target/bin/postfix-summary
+++ b/target/bin/postfix-summary
@@ -1,6 +1,17 @@
-#!/bin/sh
+#!/bin/bash
 
-test -x /usr/sbin/pflogsumm || exit 0
-test -x /usr/bin/bsd-mailx || exit 0
+HOSTNAME=$1
+RECIPIENT=$2
 
-/usr/sbin/pflogsumm /var/log/mail/mail.log.1 --problems-first | /usr/bin/bsd-mailx -s "Postfix Summary for HOSTNAME"  POSTFIX_SUMM_EMAIL
+errex() {
+  echo -e "$@" 1>&2
+  exit 1
+}
+
+test -x /usr/sbin/pflogsumm || errex "Critical: /usr/sbin/pflogsumm not found"
+
+BODY="Subject: Postfix Summary for $HOSTNAME\n\n"
+[ -r "/var/log/mail/mail.log.1" ] \
+  && BODY="$BODY"$(/usr/sbin/pflogsumm /var/log/mail/mail.log.1 --problems-first) \
+  || BODY="$BODY Error: Mail log not readable or not found: /var/log/mail/mail.log.1\n\nIn case of no mail activity since the last report, this might be a considered a nuisance warning.\n\nYours faithfully, The $HOSTNAME Mailserver"
+echo -e "$BODY" | sendmail -f "mailserver-report@$HOSTNAME" "$RECIPIENT"

--- a/target/bin/postfix-summary
+++ b/target/bin/postfix-summary
@@ -11,7 +11,8 @@ errex() {
 test -x /usr/sbin/pflogsumm || errex "Critical: /usr/sbin/pflogsumm not found"
 
 BODY="Subject: Postfix Summary for $HOSTNAME\n\n"
+# The case that the mail.log.1 file isn't readable shouldn't actually be possible with logrotate not rotating empty files.. But you never know!
 [ -r "/var/log/mail/mail.log.1" ] \
   && BODY="$BODY"$(/usr/sbin/pflogsumm /var/log/mail/mail.log.1 --problems-first) \
-  || BODY="$BODY Error: Mail log not readable or not found: /var/log/mail/mail.log.1\n\nIn case of no mail activity since the last report, this might be a considered a nuisance warning.\n\nYours faithfully, The $HOSTNAME Mailserver"
+  || BODY="$BODY Error: Mail log not readable or not found: /var/log/mail/mail.log.1\n\nIn case of mail inactivity since the last report, this might be considered a nuisance warning.\n\nYours faithfully, The $HOSTNAME Mailserver"
 echo -e "$BODY" | sendmail -f "mailserver-report@$HOSTNAME" "$RECIPIENT"

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -1086,7 +1086,7 @@ function _setup_elk_forwarder() {
 function _setup_mail_summary() {
 
 	notify 'inf' "Enable postfix summary with recipient $REPORT_MAIL"
-	LOGROTATE="/var/log/mail/mail.log\n{\n  compress\n  delaycompress\n"
+	LOGROTATE="/var/log/mail/mail.log\n{\n  compress\n  copytruncate\n  delaycompress\n"
 
 	case "$REPORT_INTERVAL" in
 		"daily" )
@@ -1105,7 +1105,7 @@ function _setup_mail_summary() {
 			;;
 	esac
 
-	LOGROTATE="$LOGROTATE    sharedscripts\n  postrotate\n    /usr/local/bin/postfix-summary $HOSTNAME $REPORT_MAIL > /dev/null\n  endscript\n}\n"
+	LOGROTATE="$LOGROTATE  postrotate\n    /usr/local/bin/postfix-summary $HOSTNAME $REPORT_MAIL\n  endscript\n}\n"
 	echo -e "$LOGROTATE" > /etc/logrotate.d/maillog
 }
 

--- a/target/start-mailserver.sh
+++ b/target/start-mailserver.sh
@@ -27,8 +27,8 @@ DEFAULT_VARS["POSTMASTER_ADDRESS"]="${POSTMASTER_ADDRESS:="postmaster@domain.com
 DEFAULT_VARS["POSTSCREEN_ACTION"]="${POSTSCREEN_ACTION:="enforce"}"
 DEFAULT_VARS["SPOOF_PROTECTION"]="${SPOOF_PROTECTION:="0"}"
 DEFAULT_VARS["TLS_LEVEL"]="${TLS_LEVEL:="modern"}"
-DEFAULT_VARS["POSTFIX_SUMM_EMAIL"]="${POSTFIX_SUMM_EMAIL:="0"}"
-DEFAULT_VARS["POSTFIX_LOGROTATE_INTERVAL"]="${POSTFIX_LOGROTATE_INTERVAL:="daily"}"
+DEFAULT_VARS["REPORT_MAIL"]="${REPORT_MAIL:="0"}"
+DEFAULT_VARS["REPORT_INTERVAL"]="${REPORT_INTERVAL:="daily"}"
 ##########################################################################
 # << DEFAULT VARS
 ##########################################################################
@@ -136,8 +136,9 @@ function register_functions() {
 		_register_setup_function "_setup_postfix_virtual_transport"
 	fi
 
-  _register_setup_function "_setup_postfix_summary"
-  _register_setup_function "_setup_environment"
+  if [ "$REPORT_MAIL" != 0 ]; then
+  	_register_setup_function "_setup_mail_summary"
+  fi
 
 	################### << setup funcs
 
@@ -1082,44 +1083,30 @@ function _setup_elk_forwarder() {
 		> /etc/filebeat/filebeat.yml
 }
 
-function _setup_postfix_summary() {
-	notify 'task' 'Setting up postfix summary'
+function _setup_mail_summary() {
 
-	printf "/var/log/mail/mail.log\n" > /etc/logrotate.d/maillog
-	printf "{\n" >> /etc/logrotate.d/maillog
-	printf "	compress\n" >> /etc/logrotate.d/maillog
-	printf "	delaycompress\n" >> /etc/logrotate.d/maillog
+	notify 'inf' "Enable postfix summary with recipient $REPORT_MAIL"
+	LOGROTATE="/var/log/mail/mail.log\n{\n  compress\n  delaycompress\n"
 
-	case ${DEFAULT_VARS["POSTFIX_LOGROTATE_INTERVAL"]} in
+	case "$REPORT_INTERVAL" in
 		"daily" )
 			notify 'inf' "Setting postfix summary interval to daily"
-			printf "	rotate 7\n" >> /etc/logrotate.d/maillog
-			printf "	daily\n" >> /etc/logrotate.d/maillog
+			LOGROTATE="$LOGROTATE  rotate 7\n  daily\n"
 			;;
 		"weekly" )
 			notify 'inf' "Setting postfix summary interval to weekly"
 			postconf -e "$(postconf | grep '^mynetworks =') 172.16.0.0/12"
-			printf "	rotate 4\n" >> /etc/logrotate.d/maillog
-			printf "	weekly\n" >> /etc/logrotate.d/maillog
+			LOGROTATE="$LOGROTATE  rotate 4\n  weekly\n"
 			;;
 		"monthly" )
 			notify 'inf' "Setting postfix summary interval to monthly"
 			postconf -e "$(postconf | grep '^mynetworks =') $container_ip/32"
-			printf "	rotate 12\n" >> /etc/logrotate.d/maillog
-			printf "	monthly\n" >> /etc/logrotate.d/maillog
+			LOGROTATE="$LOGROTATE  rotate 12\n  monthly\n"
 			;;
 	esac
 
-	if [[ ! ${DEFAULT_VARS["POSTFIX_SUMM_EMAIL"]} == 0 ]]; then
-		notify 'inf' "Enable postfix summary with recipient $POSTFIX_SUMM_EMAIL"
-		sed -i -r 's/HOSTNAME/'$HOSTNAME'/g' /usr/local/bin/postfix-summary
-		sed -i -r 's/POSTFIX_SUMM_EMAIL/'$POSTFIX_SUMM_EMAIL'/g' /usr/local/bin/postfix-summary
-		printf "	sharedscripts\n" >> /etc/logrotate.d/maillog
-		printf "	postrotate\n" >> /etc/logrotate.d/maillog
-		printf "		/usr/local/bin/postfix-summary > /dev/null\n" >> /etc/logrotate.d/maillog
-		printf "	endscript\n" >> /etc/logrotate.d/maillog
-	fi
-	printf "}" >> /etc/logrotate.d/maillog
+	LOGROTATE="$LOGROTATE    sharedscripts\n  postrotate\n    /usr/local/bin/postfix-summary $HOSTNAME $REPORT_MAIL > /dev/null\n  endscript\n}\n"
+	echo -e "$LOGROTATE" > /etc/logrotate.d/maillog
 }
 
 function _setup_environment() {

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -1466,6 +1466,17 @@ load 'test_helper/bats-assert/load'
 }
 
 #
+# Pflogsumm delivery check
+#
+
+@test "checking pflogsum delivery" {
+  docker exec mail $(docker exec mail grep '/usr/local/bin/postfix-summary' /etc/logrotate.d/maillog)
+  sleep 10
+  run docker exec mail grep "Subject: Postfix Summary for " /var/mail/localhost.localdomain/user1/new/ -R
+  assert_success
+}
+
+#
 # PCI compliance
 #
 

--- a/test/tests.bats
+++ b/test/tests.bats
@@ -1470,11 +1470,12 @@ load 'test_helper/bats-assert/load'
 #
 
 @test "checking pflogsum delivery" {
-  docker exec mail $(docker exec mail grep '/usr/local/bin/postfix-summary' /etc/logrotate.d/maillog)
+  docker exec mail logrotate --force /etc/logrotate.d/maillog
   sleep 10
   run docker exec mail grep "Subject: Postfix Summary for " /var/mail/localhost.localdomain/user1/new/ -R
   assert_success
 }
+
 
 #
 # PCI compliance


### PR DESCRIPTION
See gitter.
Changed the variable name to `LOG_ROTATION_INTERVAL`.
Separated the setup of logrotate and the report sending.
Changed the postfix-summary script to accept the Hostname and Recipient as arguments.